### PR TITLE
Feature: allow for blueprint-specified tags on adLib pieces

### DIFF
--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -181,6 +181,8 @@ export interface IBlueprintAdLibPiece extends IBlueprintPieceGeneric {
 	invalid?: boolean
 	/** Expected duration of the piece, in milliseconds */
 	expectedDuration?: number
+	/** User-defined tags that can be used for filtering in the Rundown Layouts without modifying the label */
+	tags?: string[]
 }
 /** The AdLib piece sent from Core */
 export interface IBlueprintAdLibPieceDB extends IBlueprintAdLibPiece {


### PR DESCRIPTION
This will allow blueprints to provide custom tags on adLibs that can be later used for detailed filtering in the Rundown Layouts without modifying the piece label.