### PR TITLE
chore: remove hack properties on part

### DIFF
--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -97,11 +97,6 @@ export interface IBlueprintPart {
 	/** Expected duration of the line, in milliseconds */
 	expectedDuration?: number
 
-	/** The type of the segmentLiene, could be the name of the template that created it */
-	typeVariant: string
-	/** The subtype fo the part */
-	subTypeVariant?: string
-
 	/** Whether this segment line supports being used in HOLD */
 	holdMode?: PartHoldMode
 


### PR DESCRIPTION
This is information that should not be needed by core, as it is a relic of the previous blueprint flow.

The one use in the blueprints can be easily replaced, and the one use in core should be resolved in a better way first by https://app.asana.com/0/1139204570949020/1153406321864650
