### PR TITLE
[TV 2 Contributions] More additions to 2020Q1

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -10,4 +10,4 @@ export type TableConfigItemValue = Array<{
 	_id: string
 	[key: string]: BasicConfigItemValue
 }>
-export type BasicConfigItemValue = string | number | boolean
+export type BasicConfigItemValue = string | number | boolean | string[]

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,7 +54,12 @@ export interface ConfigManifestEntryEnum extends ConfigManifestEntryBase {
 }
 export interface ConfigManifestEntryTable extends ConfigManifestEntryBase {
 	type: ConfigManifestEntryType.TABLE
-	columns: BasicConfigManifestEntry[]
+	columns: Array<
+		BasicConfigManifestEntry & {
+			/** Column rank (left to right, lowest to highest) */
+			rank: number
+		}
+	>
 	defaultVal: TableConfigItemValue
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,16 @@
+import { DeviceType } from 'timeline-state-resolver-types'
 import { ConfigItemValue, TableConfigItemValue } from './common'
+import { SourceLayerType } from './content'
 
 export enum ConfigManifestEntryType {
 	STRING = 'string',
 	NUMBER = 'number',
 	BOOLEAN = 'boolean',
 	ENUM = 'enum',
-	TABLE = 'table'
+	TABLE = 'table',
+	SELECT = 'select',
+	SOURCE_LAYERS = 'source_layers',
+	LAYER_MAPPINGS = 'layer_mappings'
 }
 
 export type BasicConfigManifestEntry =
@@ -13,6 +18,12 @@ export type BasicConfigManifestEntry =
 	| ConfigManifestEntryNumber
 	| ConfigManifestEntryBoolean
 	| ConfigManifestEntryEnum
+	| ConfigManifestEntrySelectFromOptions<true>
+	| ConfigManifestEntrySelectFromOptions<false>
+	| ConfigManifestEntrySourceLayers<true>
+	| ConfigManifestEntrySourceLayers<false>
+	| ConfigManifestEntryLayerMappings<true>
+	| ConfigManifestEntryLayerMappings<false>
 
 export type ConfigManifestEntry = BasicConfigManifestEntry | ConfigManifestEntryTable
 
@@ -45,4 +56,30 @@ export interface ConfigManifestEntryTable extends ConfigManifestEntryBase {
 	type: ConfigManifestEntryType.TABLE
 	columns: BasicConfigManifestEntry[]
 	defaultVal: TableConfigItemValue
+}
+
+interface ConfigManifestEntrySelectBase<Multiple extends boolean> extends ConfigManifestEntryBase {
+	defaultVal: Multiple extends true ? string[] : string
+	multiple: Multiple
+}
+
+export interface ConfigManifestEntrySelectFromOptions<Multiple extends boolean>
+	extends ConfigManifestEntrySelectBase<Multiple> {
+	type: ConfigManifestEntryType.SELECT
+	options: string[]
+}
+
+export interface ConfigManifestEntrySourceLayers<Multiple extends boolean>
+	extends ConfigManifestEntrySelectBase<Multiple> {
+	type: ConfigManifestEntryType.SOURCE_LAYERS
+	filters?: {
+		sourceLayerTypes?: SourceLayerType[]
+	}
+}
+export interface ConfigManifestEntryLayerMappings<Multiple extends boolean>
+	extends ConfigManifestEntrySelectBase<Multiple> {
+	type: ConfigManifestEntryType.LAYER_MAPPINGS
+	filters?: {
+		deviceTypes?: DeviceType[]
+	}
 }

--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -246,6 +246,12 @@ export interface IBlueprintPieceGeneric {
 	toBeQueued?: boolean
 	/** Array of items expected to be played out. This is used by playout-devices to preload stuff. */
 	expectedPlayoutItems?: ExpectedPlayoutItemGeneric[]
+	/** When queued, should the adlib autonext */
+	adlibAutoNext?: boolean
+	/** When queued, how much overlap with the next part */
+	adlibAutoNextOverlap?: number
+	/** When queued, block transition at the end of the part */
+	adlibDisableOutTransition?: boolean
 }
 
 export interface ExpectedPlayoutItemGeneric {


### PR DESCRIPTION
Adds the following properties used by core:
- Transition properties.
  - Allows adlibs to become parts which have transition properties when queued, enabling a full in-and-out transition with autonext to be adlibbed.
- Adds select type to config manifest.
  - Allows the blueprints to expose dropdowns that can be either single-select or multiselect. The blueprints can present a list of acceptable inputs, or they can use the "Source Layer" or "Layer Mapping" types to request that core presents a list of available source layers or layer mappings to the user.
- Table column ranks.
  - Allows the blueprints to change the order in which columns in tables are presented by assigning a rank to each column (lowest rank on the left, highest on the right).