### PR TITLE
AsRun data and queueForLater

### DIFF
--- a/src/asRunLog.ts
+++ b/src/asRunLog.ts
@@ -23,6 +23,7 @@ export interface IBlueprintAsRunLogEvent {
 	rehersal: boolean
 }
 export enum IBlueprintAsRunLogEventContent {
+	DATACHANGED = 'dataChanged',
 	STARTEDPLAYBACK = 'startedPlayback',
 	STOPPEDPLAYBACK = 'stoppedPlayback'
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,7 @@
 import { IBlueprintAsRunLogEvent } from './asRunLog'
 import { ConfigItemValue } from './common'
 import { IngestPart, IngestRundown } from './ingest'
+import { IBlueprintExternalMessageQueueObj } from './message'
 import {
 	BlueprintRuntimeArguments,
 	IBlueprintPartDB,
@@ -86,6 +87,9 @@ export interface AsRunEventContext extends RundownContext {
 
 	/** Get all asRunEvents in the rundown */
 	getAllAsRunEvents(): Readonly<IBlueprintAsRunLogEvent[]>
+
+	/** Get all unsent and queued messages in the rundown */
+	getAllQueuedMessages(): Readonly<IBlueprintExternalMessageQueueObj[]>
 
 	/** Originals */
 

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,8 +1,13 @@
 import { Time } from './common'
 
 export interface IBlueprintExternalMessageQueueObj {
+	/** If set, the message references an existing message (that is to be overrritten) */
+	_id?: string
+
 	/** Type of message */
 	type: IBlueprintExternalMessageQueueType
+	/** If true, the message won't be sent automatically */
+	queueForLater?: boolean
 	/** Receiver details */
 	receiver: any
 	/** Messate details */

--- a/src/message.ts
+++ b/src/message.ts
@@ -6,9 +6,10 @@ export interface IBlueprintExternalMessageQueueObj {
 
 	/** Type of message */
 	type: IBlueprintExternalMessageQueueType
-	/** If true, the message won't be sent automatically */
-	queueForLater?: boolean
-	/** The reason for why the message was queued and not sent */
+	/**
+	 * If set, the message won't be sent automatically.
+	 * Contains the reason for why the message was queued and not sent.
+	 */
 	queueForLaterReason?: string
 	/** Receiver details */
 	receiver: any

--- a/src/message.ts
+++ b/src/message.ts
@@ -8,6 +8,8 @@ export interface IBlueprintExternalMessageQueueObj {
 	type: IBlueprintExternalMessageQueueType
 	/** If true, the message won't be sent automatically */
 	queueForLater?: boolean
+	/** The reason for why the message was queued and not sent */
+	queueForLaterReason?: string
 	/** Receiver details */
 	receiver: any
 	/** Messate details */


### PR DESCRIPTION
Adds typings for the new QueueForLater data-flow, allowing blueprints to generate and put asRun-messages on hold for later, in case some important data is missing at the time of the asRun-event.

Another event (DATACHANGED) is added, which will call the blueprints whenever a rundown-data is changed. The idea is that the blueprints can pick up previously queued messages at that time, and rework them into ready-to-send messages.