### PR TITLE
improved playlist handling

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -180,7 +180,7 @@ export interface BlueprintResultOrderedRundowns {
 }
 
 export interface BlueprintResultRundownPlaylist {
-	playlist: IBlueprintRundownPlaylistInfo
+	playlist: Omit<IBlueprintRundownPlaylistInfo, 'externalId'>
 	/** Returns information about the order of rundowns in a playlist, null will use natural sorting on rundown name */
 	order: BlueprintResultOrderedRundowns | null
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,7 +13,7 @@ import {
 	SegmentContext,
 	ShowStyleContext,
 } from './context'
-import { IngestAdlib, IngestRundown, IngestSegment } from './ingest'
+import { IngestAdlib, ExtendedIngestRundown, IngestSegment } from './ingest'
 import { IBlueprintExternalMessageQueueObj } from './message'
 import { MigrationStep } from './migrations'
 import {
@@ -24,6 +24,7 @@ import {
 	IBlueprintRundown,
 	IBlueprintRundownPlaylistInfo,
 	IBlueprintSegment,
+	IBlueprintRundownDB,
 } from './rundown'
 import { IBlueprintShowStyleBase, IBlueprintShowStyleVariant } from './showStyle'
 import { OnGenerateTimelineObj } from './timeline'
@@ -74,11 +75,11 @@ export interface StudioBlueprintManifest extends BlueprintManifestBase {
 	getShowStyleId: (
 		context: IStudioConfigContext,
 		showStyles: IBlueprintShowStyleBase[],
-		ingestRundown: IngestRundown
+		ingestRundown: ExtendedIngestRundown
 	) => string | null
 
 	/** Returns information about the playlist this rundown is a part of, return null to not make it a part of a playlist */
-	getRundownPlaylistInfo?: (rundowns: IBlueprintRundown[]) => BlueprintResultRundownPlaylist | null
+	getRundownPlaylistInfo?: (rundowns: IBlueprintRundownDB[]) => BlueprintResultRundownPlaylist | null
 }
 
 export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
@@ -96,11 +97,11 @@ export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
 	getShowStyleVariantId: (
 		context: IStudioConfigContext,
 		showStyleVariants: IBlueprintShowStyleVariant[],
-		ingestRundown: IngestRundown
+		ingestRundown: ExtendedIngestRundown
 	) => string | null
 
 	/** Generate rundown from ingest data. return null to ignore that rundown */
-	getRundown: (context: ShowStyleContext, ingestRundown: IngestRundown) => BlueprintResultRundown
+	getRundown: (context: ShowStyleContext, ingestRundown: ExtendedIngestRundown) => BlueprintResultRundown
 
 	/** Generate segment from ingest data */
 	getSegment: (context: SegmentContext, ingestSegment: IngestSegment) => BlueprintResultSegment

--- a/src/api.ts
+++ b/src/api.ts
@@ -180,7 +180,7 @@ export interface BlueprintResultOrderedRundowns {
 }
 
 export interface BlueprintResultRundownPlaylist {
-	playlist: Omit<IBlueprintRundownPlaylistInfo, 'externalId'>
+	playlist: IBlueprintRundownPlaylistInfo
 	/** Returns information about the order of rundowns in a playlist, null will use natural sorting on rundown name */
 	order: BlueprintResultOrderedRundowns | null
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
 import { IBlueprintAsRunLogEvent } from './asRunLog'
 import { ConfigItemValue } from './common'
-import { IngestPart, IngestRundown } from './ingest'
+import { IngestPart, ExtendedIngestRundown } from './ingest'
 import { IBlueprintExternalMessageQueueObj } from './message'
 import { OmitId } from './lib'
 import {
@@ -173,7 +173,7 @@ export interface AsRunEventContext extends RundownContext {
 	/** Ingest Data */
 
 	/** Get the ingest data related to the rundown */
-	getIngestDataForRundown(): Readonly<IngestRundown> | undefined
+	getIngestDataForRundown(): Readonly<ExtendedIngestRundown> | undefined
 
 	/** Get the ingest data related to a part */
 	getIngestDataForPart(part: Readonly<IBlueprintPartDB>): Readonly<IngestPart> | undefined

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -1,3 +1,5 @@
+import { IBlueprintRundownDBData } from './rundown'
+
 export interface IngestRundown {
 	/** Id of the rundown as reported by the ingest gateway. Must be unique for each rundown owned by the gateway */
 	externalId: string
@@ -48,4 +50,8 @@ export interface IngestAdlib {
 	payloadType: string
 	/** Raw payload of the adlib. Only used by the blueprints */
 	payload?: any
+}
+/** The IngesteRundown is extended with data from Core */
+export interface ExtendedIngestRundown extends IngestRundown {
+	coreData: IBlueprintRundownDBData | undefined
 }

--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -37,7 +37,9 @@ export interface IBlueprintRundown {
 	playlistExternalId?: string
 }
 /** The Rundown sent from Core */
-export interface IBlueprintRundownDB extends IBlueprintRundown {
+export interface IBlueprintRundownDB extends IBlueprintRundown, IBlueprintRundownDBData {}
+/** Properties added to a rundown in Core */
+export interface IBlueprintRundownDBData {
 	_id: string
 
 	/** Id of the showStyle variant used */
@@ -48,6 +50,9 @@ export interface IBlueprintRundownDB extends IBlueprintRundown {
 
 	/** Rundown's place in the RundownPlaylist */
 	_rank?: number
+
+	/** Air-status, comes from NCS, examples: "READY" | "NOT READY" */
+	airStatus?: string
 }
 
 /** Collection of runtime arguments to apply */

--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -7,8 +7,6 @@ export interface IBlueprintRundownPlaylistInfo {
 	/** Rundown playlist slug - user-presentable name */
 	name: string
 
-	externalId: string
-
 	/** Expected start should be set to the expected time this rundown playlist should run on air */
 	expectedStart?: Time
 	/** Expected duration of the rundown playlist */


### PR DESCRIPTION
add ExtendedIngestRundown type, to allow blueprint to use properties from Core, that are not present in IngestRundown, to allow blueprint to gain access to some Core-specific rundown properties