### PR TITLE
feat: Allow adlib actions to call take

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -109,6 +109,9 @@ export interface ActionExecutionContext extends ShowStyleContext {
 	/** Stop piecesInstances by id. Returns ids of piecesInstances that were removed */
 	stopPieceInstances(pieceInstanceIds: string[], timeOffset?: number): string[]
 
+	/** Set flag to perform take after executing the current action. Returns state of the flag after each call. */
+	takeAfterExecuteAction(take: boolean): boolean
+
 	/** Misc actions */
 	// updateAction(newManifest: Pick<IBlueprintAdLibActionManifest, 'description' | 'payload'>): void // only updates itself. to allow for the next one to do something different
 	// executePeripheralDeviceAction(deviceId: string, functionName: string, args: any[]): Promise<any>


### PR DESCRIPTION
This adds the `takeAfterExecuteAction` function which allows adlib actions to perform the take action via the UserActionAPI. The function takes a boolean parameter, which is to set whether to take or not, and returns the status of the flag after each call - in case core has decided that taking is not allowed at the current time.