### PR TITLE
feat/refactor: Blueprint config structure and parsing

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -83,7 +83,7 @@ export interface StudioBlueprintManifest extends BlueprintManifestBase {
 	getRundownPlaylistInfo?: (rundowns: IBlueprintRundownDB[]) => BlueprintResultRundownPlaylist | null
 
 	/** Process config before storing it by core to later be returned by context's getShowStyleConfig */
-	parseConfig?: (config: IBlueprintConfig) => any
+	parseConfig?: (config: IBlueprintConfig) => unknown
 }
 
 export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
@@ -117,7 +117,7 @@ export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
 	getAdlibItem?: (context: ShowStyleContext, ingestItem: IngestAdlib) => IBlueprintAdLibPiece | null
 
 	/** Process config before storing it by core to later be returned by context's getShowStyleConfig */
-	parseConfig?: (config: IBlueprintConfig) => any
+	parseConfig?: (config: IBlueprintConfig) => unknown
 
 	// Events
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -28,6 +28,7 @@ import {
 } from './rundown'
 import { IBlueprintShowStyleBase, IBlueprintShowStyleVariant } from './showStyle'
 import { OnGenerateTimelineObj } from './timeline'
+import { IBlueprintConfig } from './common'
 
 export enum BlueprintManifestType {
 	SYSTEM = 'system',
@@ -80,6 +81,9 @@ export interface StudioBlueprintManifest extends BlueprintManifestBase {
 
 	/** Returns information about the playlist this rundown is a part of, return null to not make it a part of a playlist */
 	getRundownPlaylistInfo?: (rundowns: IBlueprintRundownDB[]) => BlueprintResultRundownPlaylist | null
+
+	/** Process config before storing it by core to later be returned by context's getShowStyleConfig */
+	parseConfig?: (config: IBlueprintConfig) => any
 }
 
 export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
@@ -111,6 +115,9 @@ export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
 
 	/** Generate adlib piece from ingest data */
 	getAdlibItem?: (context: ShowStyleContext, ingestItem: IngestAdlib) => IBlueprintAdLibPiece | null
+
+	/** Process config before storing it by core to later be returned by context's getShowStyleConfig */
+	parseConfig?: (config: IBlueprintConfig) => any
 
 	// Events
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -82,8 +82,8 @@ export interface StudioBlueprintManifest extends BlueprintManifestBase {
 	/** Returns information about the playlist this rundown is a part of, return null to not make it a part of a playlist */
 	getRundownPlaylistInfo?: (rundowns: IBlueprintRundownDB[]) => BlueprintResultRundownPlaylist | null
 
-	/** Process config before storing it by core to later be returned by context's getShowStyleConfig */
-	parseConfig?: (config: IBlueprintConfig) => unknown
+	/** Preprocess config before storing it by core to later be returned by context's getStudioConfig. If not provided, getStudioConfig will return unprocessed blueprint config */
+	preprocessConfig?: (config: IBlueprintConfig) => unknown
 }
 
 export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
@@ -116,8 +116,8 @@ export interface ShowStyleBlueprintManifest extends BlueprintManifestBase {
 	/** Generate adlib piece from ingest data */
 	getAdlibItem?: (context: ShowStyleContext, ingestItem: IngestAdlib) => IBlueprintAdLibPiece | null
 
-	/** Process config before storing it by core to later be returned by context's getShowStyleConfig */
-	parseConfig?: (config: IBlueprintConfig) => unknown
+	/** Preprocess config before storing it by core to later be returned by context's getShowStyleConfig. If not provided, getShowStyleConfig will return unprocessed blueprint config */
+	preprocessConfig?: (config: IBlueprintConfig) => unknown
 
 	// Events
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,11 +1,10 @@
 export type Time = number
 
-export interface IConfigItem {
-	_id: string
-	value: ConfigItemValue
+export interface IBlueprintConfig {
+	[key: string]: ConfigItemValue
 }
 
-export type ConfigItemValue = BasicConfigItemValue | TableConfigItemValue
+export type ConfigItemValue = BasicConfigItemValue | TableConfigItemValue | IBlueprintConfig
 export type TableConfigItemValue = {
 	_id: string
 	[key: string]: BasicConfigItemValue

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,4 @@
 import { IBlueprintAsRunLogEvent } from './asRunLog'
-import { ConfigItemValue } from './common'
 import { IngestPart, ExtendedIngestRundown } from './ingest'
 import { IBlueprintExternalMessageQueueObj } from './message'
 import { OmitId } from './lib'
@@ -38,8 +37,8 @@ export interface NotesContext extends ICommonContext {
 /** Studio */
 
 export interface IStudioConfigContext {
-	/** Returns a map of the studio configs */
-	getStudioConfig: () => Readonly<{ [key: string]: ConfigItemValue }>
+	/** Returns the Studio blueprint config */
+	getStudioConfig: () => unknown
 	/** Returns a reference to a studio config value, that can later be resolved in Core */
 	getStudioConfigRef(configKey: string): string
 }
@@ -51,8 +50,8 @@ export interface IStudioContext extends IStudioConfigContext {
 /** Show Style Variant */
 
 export interface IShowStyleConfigContext {
-	/** Returns a map of the ShowStyle configs */
-	getShowStyleConfig: () => Readonly<{ [key: string]: ConfigItemValue }>
+	/** Returns a ShowStyle blueprint config */
+	getShowStyleConfig: () => unknown
 	/** Returns a reference to a showStyle config value, that can later be resolved in Core */
 	getShowStyleConfigRef(configKey: string): string
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -37,7 +37,7 @@ export interface NotesContext extends ICommonContext {
 /** Studio */
 
 export interface IStudioConfigContext {
-	/** Returns the Studio blueprint config */
+	/** Returns the Studio blueprint config. If StudioBlueprintManifest.preprocessConfig is provided, a config preprocessed by that function is returned, otherwise it is returned unprocessed */
 	getStudioConfig: () => unknown
 	/** Returns a reference to a studio config value, that can later be resolved in Core */
 	getStudioConfigRef(configKey: string): string
@@ -50,7 +50,7 @@ export interface IStudioContext extends IStudioConfigContext {
 /** Show Style Variant */
 
 export interface IShowStyleConfigContext {
-	/** Returns a ShowStyle blueprint config */
+	/** Returns a ShowStyle blueprint config. If ShowStyleBlueprintManifest.preprocessConfig is provided, a config preprocessed by that function is returned, otherwise it is returned unprocessed */
 	getShowStyleConfig: () => unknown
 	/** Returns a reference to a showStyle config value, that can later be resolved in Core */
 	getShowStyleConfigRef(configKey: string): string

--- a/src/showStyle.ts
+++ b/src/showStyle.ts
@@ -1,5 +1,5 @@
-import { IConfigItem } from './common'
 import { SourceLayerType } from './content'
+import { IBlueprintConfig } from './common'
 
 export interface IBlueprintShowStyleBase {
 	_id: string
@@ -13,14 +13,14 @@ export interface IBlueprintShowStyleBase {
 	sourceLayers: ISourceLayer[]
 
 	/** Config values are used by the Blueprints */
-	config: IConfigItem[]
+	blueprintConfig: IBlueprintConfig
 }
 export interface IBlueprintShowStyleVariant {
 	_id: string
 	name: string
 
 	/** Config values are used by the Blueprints */
-	config: IConfigItem[]
+	blueprintConfig: IBlueprintConfig
 }
 
 /** A single source layer, f.g Cameras, VT, Graphics, Remotes */


### PR DESCRIPTION
This PR changes how the blueprint config is stored in Studios and ShowStyles. Instead of an array of `_id`-`value` pairs, an object with `string` index will be used.
Additionally, optional `parseConfig` blueprint callbacks are added to `StudioBlueprintManifest` and `ShowStyleBlueprintManifest`. They will be called by Core only when the config changes, in order to let the blueprints process it e.g. by performing calculations and adding data. This will prevent repeating the same processing during other actions. Core will cache the processed configs and return them with context's `getStudioConfig` and `getShowStyleConfig` methods. If `parseConfig` is not provided, context will return unprocessed configs.