### PR TITLE
Tally tags

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -11,6 +11,10 @@ export interface IBlueprintActionManifestDisplay {
 	_rank?: number
 
 	tags?: string[]
+	/** Piece tags to use to determine if action is on-air */
+	onAirTags?: string[]
+	/** Piece tags to use to determine if action is set as next */
+	setNextTags?: string[]
 }
 
 export interface IBlueprintActionManifestDisplayContent extends IBlueprintActionManifestDisplay {

--- a/src/action.ts
+++ b/src/action.ts
@@ -11,10 +11,10 @@ export interface IBlueprintActionManifestDisplay {
 	_rank?: number
 
 	tags?: string[]
-	/** Piece tags to use to determine if action is on-air */
-	onAirTags?: string[]
+	/** Piece tags to use to determine if action is currently active */
+	currentPieceTags?: string[]
 	/** Piece tags to use to determine if action is set as next */
-	setNextTags?: string[]
+	nextPieceTags?: string[]
 }
 
 export interface IBlueprintActionManifestDisplayContent extends IBlueprintActionManifestDisplay {

--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -307,10 +307,10 @@ export interface IBlueprintAdLibPiece extends IBlueprintPieceGeneric {
 	expectedDuration?: number
 	/** When the NRCS informs us that the producer marked the part as floated, we can prevent the user from TAKE'ing it, but still have it visible and allow manipulation */
 	floated?: boolean
-	/** Piece tags to use to determine if adlib is on-air */
-	onAirTags?: string[]
-	/** Piece tags to use to determine if adlib is set as next */
-	setNextTags?: string[]
+	/** Piece tags to use to determine if action is currently active */
+	currentPieceTags?: string[]
+	/** Piece tags to use to determine if action is set as next */
+	nextPieceTags?: string[]
 }
 /** The AdLib piece sent from Core */
 export interface IBlueprintAdLibPieceDB extends IBlueprintAdLibPiece {

--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -248,6 +248,8 @@ export interface IBlueprintPieceGeneric {
 	adlibAutoNextOverlap?: number
 	/** When queued, block transition at the end of the part */
 	adlibDisableOutTransition?: boolean
+	/** User-defined tags that can be used for filtering adlibs in the shelf and identifying pieces by actions */
+	tags?: string[]
 }
 
 export interface ExpectedPlayoutItemGeneric {
@@ -303,13 +305,12 @@ export interface IBlueprintAdLibPiece extends IBlueprintPieceGeneric {
 	invalid?: boolean
 	/** Expected duration of the piece, in milliseconds */
 	expectedDuration?: number
-	/** User-defined tags that can be used for filtering in the Rundown Layouts without modifying the label */
-	tags?: string[]
 	/** When the NRCS informs us that the producer marked the part as floated, we can prevent the user from TAKE'ing it, but still have it visible and allow manipulation */
 	floated?: boolean
-
-	// TODO - stricter range of lifespan
-	// lifespan: PieceLifespan
+	/** Piece tags to use to determine if adlib is on-air */
+	onAirTags?: string[]
+	/** Piece tags to use to determine if adlib is set as next */
+	setNextTags?: string[]
 }
 /** The AdLib piece sent from Core */
 export interface IBlueprintAdLibPieceDB extends IBlueprintAdLibPiece {


### PR DESCRIPTION
Adds the property `tags` to pieces, and the properties `onAirTags` and `setNextTags` to adLibs and adLib actions.