### PR TITLE
Fix: timeline enable

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,3 @@
-import { TSRTimelineObjBase } from 'timeline-state-resolver-types'
-
 import { ActionUserData, IBlueprintActionManifest } from './action'
 import { ConfigManifestEntry } from './config'
 import {
@@ -28,7 +26,7 @@ import {
 	IBlueprintRundownDB,
 } from './rundown'
 import { IBlueprintShowStyleBase, IBlueprintShowStyleVariant } from './showStyle'
-import { OnGenerateTimelineObj } from './timeline'
+import { OnGenerateTimelineObj, TimelineObjectSofieBase } from './timeline'
 import { IBlueprintConfig } from './common'
 
 export enum BlueprintManifestType {
@@ -71,7 +69,7 @@ export interface StudioBlueprintManifest extends BlueprintManifestBase {
 	studioMigrations: MigrationStep[]
 
 	/** Returns the items used to build the baseline (default state) of a studio, this is the baseline used when there's no active rundown */
-	getBaseline: (context: IStudioContext) => TSRTimelineObjBase[]
+	getBaseline: (context: IStudioContext) => TimelineObjectSofieBase[]
 
 	/** Returns the id of the show style to use for a rundown, return null to ignore that rundown */
 	getShowStyleId: (
@@ -164,7 +162,7 @@ export interface BlueprintResultRundown {
 	rundown: IBlueprintRundown
 	globalAdLibPieces: IBlueprintAdLibPiece[]
 	globalActions?: IBlueprintActionManifest[]
-	baseline: TSRTimelineObjBase[]
+	baseline: TimelineObjectSofieBase[]
 }
 export interface BlueprintResultSegment {
 	segment: IBlueprintSegment

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -46,18 +46,28 @@ export enum TimelineObjHoldMode {
 	EXCEPT = 2, // Only use when not in HOLD
 }
 
-export interface TimelineObjectCoreExt<TMetadata = unknown, TKeyframeMetadata = unknown>
-	extends TSR.TSRTimelineObjBase {
-	// Even though timeline supports enable being an array, we're not using that feature in Sofie:
+export interface TimelineObjectSofieBase extends Omit<TSR.TSRTimelineObjBase, 'children'> {
+	// Even though Timeline supports enable being an array, we're not using that feature in Sofie:
 	enable: TSR.Timeline.TimelineEnable
+	children?: TimelineObjectSofieBase[]
 
+	keyframes?: CombineArrayType<
+		TSR.TSRTimelineObjBase['keyframes'],
+		{
+			enable: TimelineObjectSofieBase['enable']
+		}
+	>
+}
+
+export interface TimelineObjectCoreExt<TMetadata = unknown, TKeyframeMetadata = unknown>
+	extends TimelineObjectSofieBase {
 	/** Restrict object usage according to whether we are currently in a hold */
 	holdMode?: TimelineObjHoldMode
 	/** Arbitrary data storage for plugins */
 	metaData?: TMetadata
 	/** Keyframes: Arbitrary data storage for plugins */
 	keyframes?: CombineArrayType<
-		TSR.TSRTimelineObjBase['keyframes'],
+		TimelineObjectSofieBase['keyframes'],
 		{
 			metaData?: TKeyframeMetadata
 			/** Whether to keep this keyframe when the object is copied for lookahead. By default all keyframes are removed */

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -48,6 +48,9 @@ export enum TimelineObjHoldMode {
 
 export interface TimelineObjectCoreExt<TMetadata = unknown, TKeyframeMetadata = unknown>
 	extends TSR.TSRTimelineObjBase {
+	// Even though timeline supports enable being an array, we're not using that feature in Sofie:
+	enable: TSR.Timeline.TimelineEnable
+
 	/** Restrict object usage according to whether we are currently in a hold */
 	holdMode?: TimelineObjHoldMode
 	/** Arbitrary data storage for plugins */


### PR DESCRIPTION
The updated timeline dep allows `enable` to be an array, something that is backwards-compatible runtime-wise, but requires a lot of code changes to handle the new type (static type checking / on compile-time).

Since we're not using the array feature, I suggest that we opt-out of using that, to allow us not to have to update the code in a LOT of places (in blueprints and in Core).