### PR TITLE
chore(circleci): add auth params for pulling images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   test-node-10:
     docker:
       - image: circleci/node:10
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     working_directory: ~/project
     steps:
       - checkout
@@ -20,6 +23,9 @@ jobs:
   test-node-12:
     docker:
       - image: circleci/node:12
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     working_directory: ~/project
     steps:
       - checkout
@@ -56,6 +62,9 @@ jobs:
   test-node-latest:
     docker:
       - image: circleci/node
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     working_directory: ~/project
     steps:
       - checkout
@@ -73,6 +82,9 @@ jobs:
   validate-dependencies:
     docker:
       - image: circleci/node:12
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     working_directory: ~/project
     steps:
       - checkout
@@ -95,6 +107,9 @@ jobs:
   validate-all-dependencies:
     docker:
       - image: circleci/node:12
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     working_directory: ~/project
     steps:
       - checkout
@@ -111,6 +126,9 @@ jobs:
   release:
     docker:
       - image: circleci/node:12
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     working_directory: ~/project
     steps:
       - attach_workspace:
@@ -161,6 +179,9 @@ jobs:
   prerelease:
     docker:
       - image: circleci/node:12
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASS
     working_directory: ~/project
     steps:
       - attach_workspace:


### PR DESCRIPTION
> On November 1st, Docker Hub will begin limiting anonymous image pulls. We want to make sure you know how you might be impacted and what you can do to avoid interruptions to your workflow.
> 
> Adding Docker authentication to your pipeline config is the easiest way to avoid any service disruptions. If you use the Docker executor or pull Docker images when using the machine executor on CircleCI, we encourage you to authenticate. Because the anonymous API rate limits are based on IP addresses, they will impact CircleCI cloud customers. Authenticated users get higher per-user rate limits, regardless of IP.
> 
> We are currently working on a partnership with Docker to minimize the impact of this change for our users and will share more details as we get them.

This adds the required authentication parameters using the existing variables used to publish images.

Note: these parameters will not be defined in any external PRs (eg from tv2).

When porting this to other repos, be sure to define the DOCKERHUB_USERNAME and DOCKERHUB_PASS environment variables