### PR TITLE
feat: add property description to Rundown

### DIFF
--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -22,6 +22,9 @@ export interface IBlueprintRundown {
 	/** Rundown slug - user-presentable name */
 	name: string
 
+	/** Rundown description: Longer user-presentable description of the rundown */
+	description?: string
+
 	/** Expected start should be set to the expected time this rundown should run on air */
 	expectedStart?: Time
 	/** Expected duration of the rundown */


### PR DESCRIPTION
This PR adds an optional `description` field to the Rundown.

The idea behind this is to use it for additional info from NRCS (like rundown file path, etc) that might be useful to users.