### PR TITLE
chore: remove AsRunEventContext getIngestData* functions [publish]

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,4 @@
 import { IBlueprintAsRunLogEvent } from './asRunLog'
-import { IngestPart, ExtendedIngestRundown } from './ingest'
 import { IBlueprintExternalMessageQueueObj } from './message'
 import { OmitId } from './lib'
 import {
@@ -177,15 +176,4 @@ export interface AsRunEventContext extends RundownContext {
 	 * @param id Id of partInstance to fetch items in
 	 */
 	getPieceInstances(partInstanceId: string): Readonly<IBlueprintPieceInstance[]>
-
-	/** Ingest Data */
-
-	/** Get the ingest data related to the rundown */
-	getIngestDataForRundown(): Readonly<ExtendedIngestRundown> | undefined
-
-	/** Get the ingest data related to a part */
-	getIngestDataForPart(part: Readonly<IBlueprintPartDB>): Readonly<IngestPart> | undefined
-
-	/** Get the ingest data related to a partInstance */
-	getIngestDataForPartInstance(partInstance: Readonly<IBlueprintPartInstance>): Readonly<IngestPart> | undefined
 }


### PR DESCRIPTION
This portion of the api is not safe to use, as the ingest data could not match the partInstance.
Instead any data which is needed should be parsed at ingest time, and stored in the part metaData field